### PR TITLE
🔀 Merge: finish deleteApplication logic

### DIFF
--- a/src/components/createApply/applicationSection/ApplicationBtn.jsx
+++ b/src/components/createApply/applicationSection/ApplicationBtn.jsx
@@ -1,13 +1,24 @@
+import { useDeleteApplication } from '@/hooks/useApplication';
 import ApplicationBtnCard from './ui/ApplicationBtnCard';
 
-export default function ApplicationBtn({ cohort }) {
+export default function ApplicationBtn({ cohort, formId }) {
+  const { isLoading, deleteApplication } = useDeleteApplication(formId);
   return (
     <ApplicationBtnCard>
       <ApplicationBtnCard.ApplicationCohort cohort={cohort} />
       <ApplicationBtnCard.Dots />
       <ApplicationBtnCard.MenuList>
-        <ApplicationBtnCard.MenuItem text='수정 하기' />
-        <ApplicationBtnCard.MenuItem text='삭제 하기' />
+        {isLoading ? (
+          <p>로딩중</p>
+        ) : (
+          <>
+            <ApplicationBtnCard.MenuItem text='수정 하기' />
+            <ApplicationBtnCard.MenuItem
+              text='삭제 하기'
+              onClick={deleteApplication}
+            />
+          </>
+        )}
       </ApplicationBtnCard.MenuList>
     </ApplicationBtnCard>
   );

--- a/src/components/createApply/applicationSection/ApplicationOnGoingContainter.jsx
+++ b/src/components/createApply/applicationSection/ApplicationOnGoingContainter.jsx
@@ -15,6 +15,7 @@ export default function ApplicationOnGoingContainer() {
             return (
               <ApplicationBtn
                 key={application.id}
+                formId={application.id}
                 cohort={`멋사 ${application.semester}기 지원서`}
               />
             );

--- a/src/components/createApply/applicationSection/ApplicationStoredContainer.jsx
+++ b/src/components/createApply/applicationSection/ApplicationStoredContainer.jsx
@@ -15,6 +15,7 @@ export default function ApplicationStoredContainer() {
             return (
               <ApplicationBtn
                 key={application.id}
+                formId={application.id}
                 cohort={`멋사 ${application.semester}기 지원서`}
               />
             );

--- a/src/components/createApply/applicationSection/ui/ApplicationBtnCard.jsx
+++ b/src/components/createApply/applicationSection/ui/ApplicationBtnCard.jsx
@@ -58,8 +58,17 @@ function MenuList({ children }) {
   return null;
 }
 
-function MenuItem({ text }) {
-  return <li className={styles['application-btn__item']}>{text}</li>;
+function MenuItem({ text, onClick }) {
+  return (
+    <li
+      className={styles['application-btn__item']}
+      onClick={function () {
+        onClick();
+      }}
+    >
+      {text}
+    </li>
+  );
 }
 
 ApplicationBtnCard.Dots = Dots;

--- a/src/hooks/useApplication.js
+++ b/src/hooks/useApplication.js
@@ -35,6 +35,33 @@ export function useGetApplication() {
   };
 }
 
+export function useDeleteApplication(formId) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const deleteApplication = useCallback(
+    async function () {
+      setIsLoading(true);
+      try {
+        const res = await APIService.private.delete(`${import.meta.env.VITE_APP_APPLICATIONS}/${formId}`);
+        if (!res) {
+          alert('지원서를 성공적으로 삭제했습니다');
+          window.location.href = '/admin/create';
+        }
+      } catch {
+        alert('지원서를 불러오는데 실패했습니다');
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [formId],
+  );
+
+  return {
+    isLoading,
+    deleteApplication,
+  };
+}
+
 export default function useApplication() {
   const nav = useNavigate();
 


### PR DESCRIPTION
## 작성 사항
1. useDeleteApplication
  - 지원서 삭제 로직 구현 
  - 삭제 후 데이터 리패칭을 위해 window.location.href 사용해 새로 고침 유발
2. ApplicationBtn.jsx
  - useDeleteApplication 훅 사용 및 로딩 상태 적용(삭제 버튼을 누른 후 또 누른 다던지, 수정하기 버튼을 누른 다던지 방지용)
 3. ApplicationOnGoingConatiner.jsx ApplictaionStoredContainer.jsx
   - formId 프로퍼티 추가