### PR TITLE
🎨 Design: 모바일 화면에서 가로 스크롤 방지 및 요소 중앙 정렬 개선

### DIFF
--- a/src/components/ProjectPage/ImagePreview.module.css
+++ b/src/components/ProjectPage/ImagePreview.module.css
@@ -115,10 +115,7 @@
   align-items: center;
   white-space: nowrap; /* 텍스트 줄바꿈 방지 */
   gap: 0.7rem;
-  flex: none; /* 크기 고정 */
-  margin-left: auto; /* 오른쪽 끝으로 정렬 */
-  margin-top: 4rem;
-  margin-right: 6rem;
+  margin-left: auto;
   padding: 2rem 1rem;
   width: 12rem;
   height: 3rem;

--- a/src/components/ProjectPage/ImagePreview.module.css
+++ b/src/components/ProjectPage/ImagePreview.module.css
@@ -3,7 +3,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 95%;
+  width: 100%;
   max-width: 120rem;
   aspect-ratio: 16 / 9;
   background-color: #e5e5e5;

--- a/src/components/ProjectPage/ProjectDetail.module.css
+++ b/src/components/ProjectPage/ProjectDetail.module.css
@@ -1,8 +1,8 @@
 .projectDetail {
   padding: 2rem;
   width: 100%;
-  max-width: 120rem;
   margin: 0 auto;
+  box-sizing: border-box;
 }
 
 .title {
@@ -44,14 +44,14 @@
 }
 
 .separator {
-  width: 95%;
+  width: 100%;
   height: 1px;
   background-color: #dadada;
   margin: 1.5rem 0;
 }
 
 .contentContainer {
-  width: 95%;
+  width: 100%;
   display: flex;
   justify-content: space-between; /* description과 teamBox를 양쪽으로 배치 */
   align-items: flex-start;

--- a/src/components/ProjectPage/ProjectForm.module.css
+++ b/src/components/ProjectPage/ProjectForm.module.css
@@ -1,8 +1,8 @@
 .formContainer {
   padding: 2rem;
   width: 100%;
-  max-width: 120rem;
   margin: 0 auto;
+  box-sizing: border-box;
 }
 
 .title {
@@ -63,10 +63,8 @@
   align-items: center;
   white-space: nowrap; /* 텍스트 줄바꿈 방지 */
   gap: 0.7rem;
-  flex: none; /* 크기 고정 */
   margin-left: auto; /* 오른쪽 끝으로 정렬 */
   margin-top: 4rem;
-  margin-right: 6rem;
   padding: 0.5rem 1rem;
   width: 10rem;
   height: 3rem;
@@ -87,14 +85,14 @@
 }
 
 .separator {
-  width: 95%;
+  width: 100%;
   height: 1px;
   background-color: #dadada;
   margin: 1.5rem 0;
 }
 
 .contentContainer {
-  width: 95%;
+  width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
@@ -181,6 +179,6 @@
   }
 
   .titleInput {
-    font-size: 3.3rem;
+    font-size: 3rem;
   }
 }


### PR DESCRIPTION
프로젝트 상세보기 페이지에서 가로 스크롤을 방지하기 위해
ImagePreview(이미지 미리보기)와 ProjectDetail(프로젝트 상세보기) 컴포넌트의 width 스타일을 수정했습니다.

수정된 스타일에 따라 요소들이 화면 중앙에 정렬되어 레이아웃을 개선했습니다.