### PR TITLE
🐛 Fix: 파일 이름이 요청되는 버그 수정

### DIFF
--- a/src/components/adminAboutPage/Registration.jsx
+++ b/src/components/adminAboutPage/Registration.jsx
@@ -82,17 +82,18 @@ export default function Registration({ users }) {
     };
 
     try {
-      if (updatedRow.image || updatedRow.image == null) {
+      if (updatedRow.image instanceof File || updatedRow.image == null) {
         const formData = new FormData();
         formData.append('image', updatedRow.image);
 
         const response = await putImage(originalUser.semester, originalUser.studentId, formData);
 
         if (!response.success) {
-          alert(`${response.message} 이미지로 다시 저장해주세요`);
+          alert(`${response.message} 이미지는 다시 저장해주세요`);
         }
-        await putProfile(originalUser.semester, originalUser.studentId, updatedData);
       }
+      await putProfile(originalUser.semester, originalUser.studentId, updatedData);
+
       originalUser.studentId = updatedRow.studentId;
       alert('저장되었습니다.');
       toggleStorage(index);

--- a/src/components/recruitPage/RecruitMain.jsx
+++ b/src/components/recruitPage/RecruitMain.jsx
@@ -1,4 +1,4 @@
-import LionImage from '@/assets/recruitPage/lionImg.svg';
+import LionImage from '@assets/homepage/lion.webp';
 import styles from './recruitMain.module.css';
 
 export default function RecruitMain() {


### PR DESCRIPTION
새로고침 하지 않고 이미지를 변경하지 않은 상태에서 저장 요청을 한번 더 보내면 파일 이름이 요청되는 버그를 파일 형식 또는 null일 때만 요청하도록 수정(파일 이름은 문자열로 들어가므로 요청이 아예 가지 않도록 됨)