### PR TITLE
🐛Fix: adminpage / mypage / footer / header / privateRoutes 수정

### DIFF
--- a/src/components/admin/Admin.jsx
+++ b/src/components/admin/Admin.jsx
@@ -14,10 +14,6 @@ function AdminTitle() {
   );
 }
 
-function AdminText() {
-  return <p className={styles.text}>admin1234@skuniv.ac.kr</p>;
-}
-
 function AdminItemBox({ children }) {
   return <div className={styles.itembox}>{children}</div>;
 }
@@ -36,6 +32,5 @@ function AdminButton({ label, path }) {
 }
 
 Admin.Title = AdminTitle;
-Admin.Text = AdminText;
 Admin.ItemBox = AdminItemBox;
 Admin.Button = AdminButton;

--- a/src/components/admin/AdminSection.jsx
+++ b/src/components/admin/AdminSection.jsx
@@ -4,7 +4,6 @@ export default function AdminSection() {
   return (
     <Admin>
       <Admin.Title />
-      <Admin.Text />
       <Admin.ItemBox>
         <Admin.Button
           label='지원서 생성하기'

--- a/src/components/commons/footer/Footer.jsx
+++ b/src/components/commons/footer/Footer.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import styles from './Footer.module.css';
@@ -8,20 +8,16 @@ import instagram from '@assets/footer/instagram.webp';
 import github from '@assets/footer/github.webp';
 
 export default function Footer() {
-  const [clickCount, setClickCount] = useState(0);
+  const clickCount = useRef(0);
   const navigate = useNavigate();
 
   function handleClick() {
-    setClickCount((prevCount) => {
-      const newCount = prevCount + 1;
+    clickCount.current += 1;
 
-      if (newCount === 3) {
-        navigate('/admin');
-        return 0;
-      }
-
-      return newCount;
-    });
+    if (clickCount.current === 3) {
+      navigate('/admin');
+      clickCount.current = 0;
+    }
   }
 
   return (

--- a/src/components/commons/header/HeaderBar.jsx
+++ b/src/components/commons/header/HeaderBar.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, createContext, useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import styles from './HeaderBar.module.css';
 import logo from '@assets/commons/logo.webp';
 import login from '@assets/header/login.webp';
@@ -11,39 +11,19 @@ const HeaderBarContext = createContext();
 export default function HeaderBar({ children }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const location = useLocation();
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
   const closeMenu = () => setIsMenuOpen(false);
 
   // 새로고침 없이 로그인 <-> 마이페이지
   useEffect(() => {
-    const checkLoginStatus = () => {
+    function checkLoginStatus() {
       const token = localStorage.getItem('token');
       setIsLoggedIn(!!token);
-    };
+    }
 
     checkLoginStatus();
-
-    const originalSetItem = localStorage.setItem;
-    localStorage.setItem = function (key) {
-      originalSetItem.apply(this, arguments);
-      if (key === 'token') {
-        checkLoginStatus();
-      }
-    };
-
-    const originalRemoveItem = localStorage.removeItem;
-    localStorage.removeItem = function (key) {
-      originalRemoveItem.apply(this, arguments);
-      if (key === 'token') {
-        checkLoginStatus();
-      }
-    };
-
-    return () => {
-      localStorage.setItem = originalSetItem;
-      localStorage.removeItem = originalRemoveItem;
-    };
-  }, []);
+  }, [location.pathname]);
 
   return (
     <div className={styles.section}>

--- a/src/components/mypage/MyPageSection.jsx
+++ b/src/components/mypage/MyPageSection.jsx
@@ -29,7 +29,6 @@ export default function MyPageSection() {
     const token = localStorage.getItem('token');
     if (!token) {
       navigate('/error');
-      console.log('success');
       return;
     }
     fetchUserData();

--- a/src/components/mypage/MyPageSection.jsx
+++ b/src/components/mypage/MyPageSection.jsx
@@ -20,11 +20,11 @@ export default function MyPageSection() {
       setUserimage(`${import.meta.env.VITE_APP_API_URL}${response.profileImageUrl}`);
       setSemester(response.semester);
       setStudentId(response.studentId);
-    } catch (error) {
-      console.error('사용자 정보를 불러오는데 실패했습니다:', error);
-      navigate('/error');
+    } catch {
+      alert('사용자 정보를 불러오는데 실패했습니다.');
     }
   }
+
   useEffect(() => {
     const token = localStorage.getItem('token');
     if (!token) {

--- a/src/components/mypage/MyPageSection.jsx
+++ b/src/components/mypage/MyPageSection.jsx
@@ -1,5 +1,6 @@
 import { APIService } from '@api/axios';
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import MyPage from './MyPage';
 
 export default function MyPageSection() {
@@ -8,6 +9,7 @@ export default function MyPageSection() {
   const [userimage, setUserimage] = useState('');
   const [semester, setSemester] = useState('');
   const [studentId, setStudentId] = useState('');
+  const navigate = useNavigate();
 
   async function fetchUserData() {
     try {
@@ -20,12 +22,18 @@ export default function MyPageSection() {
       setStudentId(response.studentId);
     } catch (error) {
       console.error('사용자 정보를 불러오는데 실패했습니다:', error);
-      location.href = '/error';
+      navigate('/error');
     }
   }
   useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      navigate('/error');
+      console.log('success');
+      return;
+    }
     fetchUserData();
-  }, []);
+  });
 
   return (
     <MyPage>

--- a/src/router/PrivateRoutes.jsx
+++ b/src/router/PrivateRoutes.jsx
@@ -25,6 +25,10 @@ export default function PrivateRoute({ children }) {
     fetchUserRole();
   }, []);
 
+  if (userRole === null) {
+    return null;
+  }
+
   if (userRole !== 'ADMIN') {
     return <Navigate to="/error" replace />;
   }


### PR DESCRIPTION
1. adminpage
불필요한 관리자 이메일 칸 삭제

2. mypage
로그인 하지 않은 채 url로 mypage 접근하면 error 페이지로 이동하게 설정

3. footer
clickCount useRef를 사용하여 카운트하도록 수정

4. header
useEffect 의존성 배열에 location.pathname 추가하여 로그인/마이페이지 헤더 상태 변경

5. privateRoutes
role이 admin이어도 관리자페이지로 이동 안되던 문제 해결