### PR TITLE
🎨 Design: imagePreviewContainer delete max-width

### DIFF
--- a/src/components/ProjectPage/ImagePreview.module.css
+++ b/src/components/ProjectPage/ImagePreview.module.css
@@ -4,7 +4,6 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  max-width: 120rem;
   aspect-ratio: 16 / 9;
   background-color: #e5e5e5;
   border-radius: 20px;


### PR DESCRIPTION
이미지가 100%로 화면에 보이기 위해서 max-width 삭제.