### PR TITLE
✨ Feat: 회원가입 성공 페이지 & 비밀번호 변경 페이지 직접 url 입력해서 접근 불가능하게 수정

### DIFF
--- a/src/components/mypage/MyPage.jsx
+++ b/src/components/mypage/MyPage.jsx
@@ -164,7 +164,7 @@ function MypageChangePW() {
   return (
     <button
       className={styles.itembox__button}
-      onClick={() => navigate('/passwordChange')}
+      onClick={() => navigate('/passwordChange', { state: { prevPage: 'AllowAccess' }, replace: true })}
     >
       비밀번호 변경
     </button>

--- a/src/components/passwordChange/PasswordChangeForm.jsx
+++ b/src/components/passwordChange/PasswordChangeForm.jsx
@@ -4,11 +4,12 @@ import { passwordChangeSchema } from '@/constants/validationSchema';
 
 import classNames from 'classnames/bind';
 import styles from './PasswordChangeForm.module.css';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Navigate } from 'react-router-dom';
 import { useState } from 'react';
 import { TailSpin } from 'react-loader-spinner';
 
 import { handlePasswordChangeClick } from '@hooks/usePasswordChangeHook';
+import { usePreventDirectAccessPWChange } from '@/hooks/usePreventDirectAccessHook';
 
 const cn = classNames.bind(styles);
 
@@ -25,6 +26,18 @@ export default function PasswordChangeForm() {
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
   const token = localStorage.getItem('token');
+
+  const isAccessSuccess = usePreventDirectAccessPWChange();
+  if (isAccessSuccess === null) return null;
+
+  if (!isAccessSuccess) {
+    return (
+      <Navigate
+        to={'/login'}
+        replace
+      />
+    );
+  }
 
   function onSubmit(userData) {
     handlePasswordChangeClick(userData, errors, setError, navigate, setIsLoading, token);

--- a/src/components/passwordChange/PasswordChangeForm.jsx
+++ b/src/components/passwordChange/PasswordChangeForm.jsx
@@ -33,7 +33,7 @@ export default function PasswordChangeForm() {
   if (!isAccessSuccess) {
     return (
       <Navigate
-        to={'/login'}
+        to={'/mypage'}
         replace
       />
     );

--- a/src/components/signup/WelcomeSection.jsx
+++ b/src/components/signup/WelcomeSection.jsx
@@ -1,4 +1,5 @@
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams, Navigate } from 'react-router-dom';
+import { usePreventDirectAccess } from '@/hooks/usePreventDirectAccessHook';
 import logo from '@assets/homepage/lion.webp';
 import styles from './WelcomeSection.module.css';
 
@@ -7,6 +8,16 @@ export default function WelcomeSection() {
   // 파라미터에서 name 읽기
   const name = searchParams.get('name') || 'GUEST';
   const navigate = useNavigate();
+
+  const isAccessSuccess = usePreventDirectAccess();
+  if (!isAccessSuccess) {
+    return (
+      <Navigate
+        to={'/'}
+        replace
+      />
+    );
+  }
 
   // 홈으로 버튼 클릭 //
   function toHomeClick(e) {

--- a/src/components/signup/WelcomeSection.jsx
+++ b/src/components/signup/WelcomeSection.jsx
@@ -10,6 +10,8 @@ export default function WelcomeSection() {
   const navigate = useNavigate();
 
   const isAccessSuccess = usePreventDirectAccess();
+  if (isAccessSuccess === null) return null;
+
   if (!isAccessSuccess) {
     return (
       <Navigate

--- a/src/hooks/usePreventDirectAccessHook.js
+++ b/src/hooks/usePreventDirectAccessHook.js
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+// WelcomeSection.jsx - 직접 url쳐서 들어오는 접근 막고 다른 페이지로 보내기
+export function usePreventDirectAccess() {
+  const [isAccessSuccess, setIsAccessSuccess] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    // 이전 페이지 정보 확인
+    if (!location.state || location.state.prevPage !== 'AllowAccess') {
+      navigate('/'); // 정상적인 접근 아니면 페이지 이동
+    } else {
+      setIsAccessSuccess(true);
+    }
+  }, [location, navigate]);
+
+  return isAccessSuccess;
+}

--- a/src/hooks/usePreventDirectAccessHook.js
+++ b/src/hooks/usePreventDirectAccessHook.js
@@ -8,7 +8,7 @@ export function usePreventDirectAccess() {
   const location = useLocation();
 
   useEffect(() => {
-    // 이전 페이지 정보 확인
+    // 이전 페이지 정보 확인(회원가입2 페이지에서 이동한게 정상)
     if (!location.state || location.state.prevPage !== 'AllowAccess') {
       navigate('/', { replace: true }); // 정상적인 접근 아니면 페이지 이동
     } else {
@@ -21,7 +21,7 @@ export function usePreventDirectAccess() {
 
 // 현재 로그인 상태인지 확인하는 함수
 function isAuthenticated() {
-  return !!localStorage.getItem('userToken'); // true면 로그인됨, false면 로그인 안 됨
+  return !!localStorage.getItem('token'); // true면 로그인됨, false면 로그인 안 됨
 }
 
 // PasswordChangeForm.jsx - 로그인한 상태에서 마이페이지에서 이동했을 때만 접근 가능하게 검사
@@ -31,16 +31,16 @@ export function usePreventDirectAccessPWChange() {
   const location = useLocation();
 
   useEffect(() => {
+    // 로그인 상태인지 확인
     const isLoggedIn = isAuthenticated();
-
     if (!isLoggedIn) {
-      navigate('/login', { replace: true });
+      navigate('/login', { replace: true }); // 아니면 로그인 페이지로 이동
       return;
     }
 
-    // 이전 페이지 정보 확인
+    // 이전 페이지 정보 확인(마이페이지에서 이동한게 정상)
     if (!location.state || location.state.prevPage !== 'AllowAccess') {
-      navigate('/login', { replace: true }); // 정상적인 접근 아니면 페이지 이동
+      navigate('/mypage', { replace: true }); // 정상적인 접근 아니면 마이페이지로 이동
     } else {
       setIsAccessSuccess(true);
     }

--- a/src/hooks/usePreventDirectAccessHook.js
+++ b/src/hooks/usePreventDirectAccessHook.js
@@ -3,18 +3,18 @@ import { useNavigate, useLocation } from 'react-router-dom';
 
 // WelcomeSection.jsx - 직접 url쳐서 들어오는 접근 막고 다른 페이지로 보내기
 export function usePreventDirectAccess() {
-  const [isAccessSuccess, setIsAccessSuccess] = useState(false);
+  const [isAccessSuccess, setIsAccessSuccess] = useState(null);
   const navigate = useNavigate();
   const location = useLocation();
 
   useEffect(() => {
     // 이전 페이지 정보 확인
     if (!location.state || location.state.prevPage !== 'AllowAccess') {
-      navigate('/'); // 정상적인 접근 아니면 페이지 이동
+      navigate('/', { replace: true }); // 정상적인 접근 아니면 페이지 이동
     } else {
       setIsAccessSuccess(true);
     }
-  }, [location, navigate]);
+  }, [location.state, navigate]);
 
   return isAccessSuccess;
 }

--- a/src/hooks/usePreventDirectAccessHook.js
+++ b/src/hooks/usePreventDirectAccessHook.js
@@ -18,3 +18,33 @@ export function usePreventDirectAccess() {
 
   return isAccessSuccess;
 }
+
+// 현재 로그인 상태인지 확인하는 함수
+function isAuthenticated() {
+  return !!localStorage.getItem('userToken'); // true면 로그인됨, false면 로그인 안 됨
+}
+
+// PasswordChangeForm.jsx - 로그인한 상태에서 마이페이지에서 이동했을 때만 접근 가능하게 검사
+export function usePreventDirectAccessPWChange() {
+  const [isAccessSuccess, setIsAccessSuccess] = useState(null);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const isLoggedIn = isAuthenticated();
+
+    if (!isLoggedIn) {
+      navigate('/login', { replace: true });
+      return;
+    }
+
+    // 이전 페이지 정보 확인
+    if (!location.state || location.state.prevPage !== 'AllowAccess') {
+      navigate('/login', { replace: true }); // 정상적인 접근 아니면 페이지 이동
+    } else {
+      setIsAccessSuccess(true);
+    }
+  }, [location.state, navigate]);
+
+  return isAccessSuccess;
+}

--- a/src/hooks/useSignupHook.js
+++ b/src/hooks/useSignupHook.js
@@ -43,7 +43,7 @@ export async function signUp(form, setSignupSuccess, setNow, navigate) {
     if (response.success) {
       setSignupSuccess(true);
       setNow(1);
-      navigate(`/welcome?name=${encodeURIComponent(form.name)}`, { state: { prevPage: 'AllowAccess' } });
+      navigate(`/welcome?name=${encodeURIComponent(form.name)}`, { state: { prevPage: 'AllowAccess' }, replace: true });
     } else {
       const tologin = confirm(response.message + ' 로그인 페이지로 이동합니다.');
       if (tologin) {

--- a/src/hooks/useSignupHook.js
+++ b/src/hooks/useSignupHook.js
@@ -43,7 +43,7 @@ export async function signUp(form, setSignupSuccess, setNow, navigate) {
     if (response.success) {
       setSignupSuccess(true);
       setNow(1);
-      navigate(`/welcome?name=${encodeURIComponent(form.name)}`);
+      navigate(`/welcome?name=${encodeURIComponent(form.name)}`, { state: { prevPage: 'AllowAccess' } });
     } else {
       const tologin = confirm(response.message + ' 로그인 페이지로 이동합니다.');
       if (tologin) {


### PR DESCRIPTION
1. 회원가입 성공 페이지: (WelcomeSection.jsx / usePreventDirectAccessHook.js / SignupSection2.jsx 수정 및 추가)
- Signup2페이지에서 회원가입 성공했을 때만 접근 가능하게 수정. (=> 다른 페이지에서 url 접근 시, 메인 홈페이지로 이동)



2. 비밀번호 변경 페이지: (PasswordChangeForm.jsx / usePreventDirectAccessHook.js / MyPage.jsx 수정 및 추가)
- 로그인 상태일 때, (=> 로그인 안 된 상태로 url 접근 시, login페이지로 이동)
- MyPage페이지에서만 접근 가능하게 수정. (=> 마이페이지 아닌 다른 페이지에서 url 접근 시, 일단은 마이페이지로 이동)

