### PR TITLE
fix: 탈퇴 이후 헤더 수정 / 디데이 두자리로 고정 / 지원기간 이후 버튼 변경

### DIFF
--- a/src/components/commons/header/HeaderBar.jsx
+++ b/src/components/commons/header/HeaderBar.jsx
@@ -34,10 +34,13 @@ export default function HeaderBar({ children }) {
           localStorage.removeItem('token');
           setIsLoggedIn(false);
           return;
+        } else {
+          setIsLoggedIn(true);
         }
-        setIsLoggedIn(true);
       } catch {
-        alert('사용자 정보를 불러오는데 실패했습니다.');
+        // 요청 실패 시에도 로그아웃 처리
+        localStorage.removeItem('token');
+        setIsLoggedIn(false);
       }
     }
 

--- a/src/components/home/recruit/Recruit.jsx
+++ b/src/components/home/recruit/Recruit.jsx
@@ -29,10 +29,10 @@ function RecruitTimerTitle() {
 
 function RecruitTimer() {
   const [timeLeft, setTimeLeft] = useState({
-    days: 0,
-    hours: 0,
-    minutes: 0,
-    seconds: 0,
+    days: '00',
+    hours: '00',
+    minutes: '00',
+    seconds: '00',
   });
 
   // 서류 마감 날짜
@@ -45,12 +45,20 @@ function RecruitTimer() {
 
       if (difference <= 0) {
         clearInterval(intervalId);
-        setTimeLeft({ days: 0, hours: 0, minutes: 0, seconds: 0 });
+        setTimeLeft({ days: '00', hours: '00', minutes: '00', seconds: '00' });
       } else {
-        const days = Math.floor(difference / (1000 * 60 * 60 * 24));
-        const hours = Math.floor((difference / (1000 * 60 * 60)) % 24);
-        const minutes = Math.floor((difference / (1000 * 60)) % 60);
-        const seconds = Math.floor((difference / 1000) % 60);
+        const days = Math.floor(difference / (1000 * 60 * 60 * 24))
+          .toString()
+          .padStart(2, '0');
+        const hours = Math.floor((difference / (1000 * 60 * 60)) % 24)
+          .toString()
+          .padStart(2, '0');
+        const minutes = Math.floor((difference / (1000 * 60)) % 60)
+          .toString()
+          .padStart(2, '0');
+        const seconds = Math.floor((difference / 1000) % 60)
+          .toString()
+          .padStart(2, '0');
 
         setTimeLeft({ days, hours, minutes, seconds });
       }
@@ -74,12 +82,37 @@ function RecruitTimer() {
 
 function RecruitButton() {
   const navigate = useNavigate();
+  const now = new Date();
+  const targetDate = new Date('2025-03-07T23:59:59');
+  const resultDate = new Date('2025-03-08T12:00:00');
+  const token = localStorage.getItem('token');
+
   return (
     <button
       className={styles.button}
-      onClick={() => navigate('recruit')}
+      onClick={() => {
+        if (now < targetDate) {
+          navigate('recruit');
+        } else if (now >= targetDate && now < resultDate) {
+          alert('지원이 마감되었습니다.');
+        } else {
+          if (!token) {
+            navigate('/error', {
+              state: {
+                msg: '로그인이 필요한 서비스입니다.',
+                msg2: '로그인 후 다시 이용해주세요.',
+                msg3: '이용에 불편을 드려 죄송합니다.',
+                btnMsg: '로그인',
+                url: '/login',
+              },
+            });
+          } else {
+            navigate('result');
+          }
+        }
+      }}
     >
-      지원하러 가기
+      {now < resultDate ? '지원하러 가기' : '결과보러 가기'}
       <img
         src={arrow}
         alt='arrow'

--- a/src/components/home/recruit/Recruit.module.css
+++ b/src/components/home/recruit/Recruit.module.css
@@ -31,7 +31,7 @@
   margin-top: 5vh;
   display: flex;
   justify-content: center;
-  gap: 7vh;
+  gap: 8.3vh;
 }
 
 .timer {


### PR DESCRIPTION
1. 사용자가 로그인 되어 있는 상태에서 탈퇴 당하면 모든 페이지에서 “사용자 정보를 불러오는데 실패했습니다.’ alert가 뜨는 문제 해결 
요청 실패시 alert 대신 로그아웃 상태 만들기

2. 디데이 두글자로 고정
 ex) 1초 -> 01초
두글자 고정을 위해 string으로 처리

3. 지원기간 이후 버튼 변경
지원마감 이전 : 지원하러 가기 버튼 (지원페이지로 이동)
지원마감 이후 결과확인 이전 : 지원하러 가기 버튼 (클릭하면 지원이 마감되었습니다 alert)
결과확인 이후: 결과보러 가기 버튼 (결과페이지로 이동)
로그인 안하고 결과보러 가기 버튼 눌렀을 때: 로그인 유도 페이지로 이동