### PR TITLE
♻️ Refactor: 역할별 정렬 토글 추가 및 index대신 loginId로 각 토글 관리하도록 변경

### DIFF
--- a/src/components/admin/AdminSection.jsx
+++ b/src/components/admin/AdminSection.jsx
@@ -18,7 +18,7 @@ export default function AdminSection() {
           path='project'
         />
         <Admin.Button
-          label='멋사인 편집하기'
+          label='구성원 편집하기'
           path='about'
         />
         <Admin.Button

--- a/src/components/adminAboutPage/Generation.jsx
+++ b/src/components/adminAboutPage/Generation.jsx
@@ -31,7 +31,7 @@ export default function Generation() {
   return (
     <div className={styles.allContainer}>
       <div className={styles.titleContainer}>
-        <p className={styles.title}>멋사인 편집하기</p>
+        <p className={styles.title}>구성원 편집하기</p>
         <div className={styles.buttonContainer}>
           <div className={styles.navbar}>
             {years.map((year) => (

--- a/src/components/adminAboutPage/Registration.jsx
+++ b/src/components/adminAboutPage/Registration.jsx
@@ -7,17 +7,22 @@ import { putProfile, putImage, deleteProfile } from '@api/aboutAdminAPI';
 
 export default function Registration({ users }) {
   const [rows, setRows] = useState([]);
-  const roleOrder = ['LEAD', 'COLEAD', 'COREMEMBER', 'BABYLION', 'GUEST'];
-  const partOrder = ['기획디자인', '기획', '디자인', '프론트엔드', '백엔드'];
+  const [filterRole, setFilterRole] = useState('전체');
+
+  const roleOrder = ['전체', 'LEAD', 'COLEAD', 'COREMEMBER', 'BABYLION', 'GUEST'];
+  const partOrder = ['지원자', '기획디자인', '기획', '디자인', '백엔드', '프론트엔드'];
 
   useEffect(() => {
     if (users && Array.isArray(users)) {
       const initialRows = users.map((user) => ({
+        loginId: user.loginId,
         role: user.role || 'GUEST',
         name: user.userName || '',
         part: user.parts || '',
         department: user.department || '',
         studentId: user.studentId || '',
+        semester: user.semester || null,
+        originalStudentId: user.studentId || '',
         image: user.profileImageUrl || '',
         isStorage: true,
       }));
@@ -29,26 +34,23 @@ export default function Registration({ users }) {
     return <p>데이터를 불러오는 중입니다...</p>;
   }
 
-  function toggleStorage(index) {
-    const updatedRows = [...rows];
-    updatedRows[index].isStorage = !updatedRows[index].isStorage;
-    setRows(updatedRows);
+  const filteredRows = filterRole === '전체' ? rows : rows.filter((row) => row.role === filterRole);
+
+  function toggleStorage(loginId) {
+    setRows(rows.map((row) => (row.loginId === loginId ? { ...row, isStorage: !row.isStorage } : row)));
   }
 
-  function handleCellChange(index, field, value) {
-    const updatedRows = [...rows];
-    updatedRows[index][field] = value;
-    setRows(updatedRows);
+  function handleCellChange(loginId, field, value) {
+    setRows(rows.map((row) => (row.loginId === loginId ? { ...row, [field]: value } : row)));
   }
 
-  async function handleDeleteRow(index) {
-    const originalUser = users[index];
-
+  async function handleDeleteRow(loginId) {
+    const originalUser = users.find((user) => user.loginId === loginId);
+    if (!originalUser) return;
     try {
       const isDeleted = await deleteProfile(originalUser.semester, originalUser.studentId);
-
       if (isDeleted) {
-        setRows(rows.filter((_, rowIndex) => rowIndex !== index));
+        setRows(rows.filter((row) => row.loginId !== loginId));
         alert('삭제되었습니다.');
       } else {
         alert('게스트만 삭제 가능합니다.');
@@ -58,16 +60,13 @@ export default function Registration({ users }) {
     }
   }
 
-  function handleImageUpload(file, index) {
-    const updatedRows = [...rows];
-    updatedRows[index].image = file === '' ? null : file;
-    setRows(updatedRows);
+  function handleImageUpload(file, loginId) {
+    setRows(rows.map((row) => (row.loginId === loginId ? { ...row, image: file === '' ? null : file } : row)));
   }
 
-  async function handleSave(index) {
-    const updatedRow = rows[index];
-    const originalUser = users[index];
-
+  async function handleSave(loginId) {
+    const updatedRow = rows.find((row) => row.loginId === loginId);
+    const originalUser = users.find((user) => user.loginId === loginId);
     if (!originalUser) {
       alert('원본 데이터를 찾을 수 없습니다.');
       return;
@@ -79,26 +78,38 @@ export default function Registration({ users }) {
       parts: updatedRow.part,
       department: updatedRow.department,
       studentId: updatedRow.studentId,
+      semester: updatedRow.semester,
     };
 
     try {
+      let imageSuccess = true;
+      let profileSuccess = true;
+
       if (updatedRow.image instanceof File || updatedRow.image == null) {
         const formData = new FormData();
         formData.append('image', updatedRow.image);
-
-        const response = await putImage(originalUser.semester, originalUser.studentId, formData);
-
-        if (!response.success) {
+        const response = await putImage(updatedRow.semester, updatedRow.originalStudentId, formData);
+        imageSuccess = response.success;
+        if (!imageSuccess) {
           alert(`${response.message} 이미지는 다시 저장해주세요`);
         }
       }
-      await putProfile(originalUser.semester, originalUser.studentId, updatedData);
 
-      originalUser.studentId = updatedRow.studentId;
-      alert('저장되었습니다.');
-      toggleStorage(index);
-    } catch {
-      alert('저장에 실패했습니다.');
+      const profileResponse = await putProfile(updatedRow.semester, updatedRow.originalStudentId, updatedData);
+      profileSuccess = profileResponse.success;
+
+      if (profileSuccess) {
+        setRows((prevRows) =>
+          prevRows.map((row) =>
+            row.loginId === loginId ? { ...row, originalStudentId: updatedRow.studentId, isStorage: true } : row,
+          ),
+        );
+
+        alert('저장되었습니다.');
+        toggleStorage(loginId);
+      }
+    } catch (error) {
+      alert(error);
     }
   }
 
@@ -106,6 +117,20 @@ export default function Registration({ users }) {
     <div className={styles.allContainer}>
       <div className={styles.titleContainer}>
         <p className={styles.titleText}>LIKELION SKU 관리</p>
+        <select
+          className={styles.filterDropdown}
+          value={filterRole}
+          onChange={(e) => setFilterRole(e.target.value)}
+        >
+          {roleOrder.map((role) => (
+            <option
+              key={role}
+              value={role}
+            >
+              {role}
+            </option>
+          ))}
+        </select>
       </div>
 
       <div className={styles.newCategoryContainer}>
@@ -123,16 +148,16 @@ export default function Registration({ users }) {
               </tr>
             </thead>
             <tbody>
-              {rows.map((row, index) => (
-                <tr key={index}>
+              {filteredRows.map((row) => (
+                <tr key={row.loginId}>
                   <td>
                     <select
                       className={styles.tableInput}
                       value={row.role}
-                      onChange={(e) => handleCellChange(index, 'role', e.target.value)}
+                      onChange={(e) => handleCellChange(row.loginId, 'role', e.target.value)}
                       disabled={row.isStorage}
                     >
-                      {roleOrder.map((role) => (
+                      {roleOrder.slice(1).map((role) => (
                         <option
                           key={role}
                           value={role}
@@ -147,7 +172,7 @@ export default function Registration({ users }) {
                       className={styles.tableInput}
                       type='text'
                       value={row.name}
-                      onChange={(e) => handleCellChange(index, 'name', e.target.value)}
+                      onChange={(e) => handleCellChange(row.loginId, 'name', e.target.value)}
                       disabled={row.isStorage}
                     />
                   </td>
@@ -155,7 +180,7 @@ export default function Registration({ users }) {
                     <select
                       className={styles.tableInput}
                       value={row.part}
-                      onChange={(e) => handleCellChange(index, 'part', e.target.value)}
+                      onChange={(e) => handleCellChange(row.loginId, 'part', e.target.value)}
                       disabled={row.isStorage}
                     >
                       {partOrder.map((part) => (
@@ -173,7 +198,7 @@ export default function Registration({ users }) {
                       className={styles.tableInput}
                       type='text'
                       value={row.department}
-                      onChange={(e) => handleCellChange(index, 'department', e.target.value)}
+                      onChange={(e) => handleCellChange(row.loginId, 'department', e.target.value)}
                       disabled={row.isStorage}
                     />
                   </td>
@@ -182,7 +207,7 @@ export default function Registration({ users }) {
                       className={styles.tableInput}
                       type='text'
                       value={row.studentId}
-                      onChange={(e) => handleCellChange(index, 'studentId', e.target.value)}
+                      onChange={(e) => handleCellChange(row.loginId, 'studentId', e.target.value)}
                       disabled={row.isStorage}
                     />
                   </td>
@@ -192,17 +217,17 @@ export default function Registration({ users }) {
                         <div className={styles.deleteButtonContainer}>
                           <MdEdit
                             style={{ color: 'black', fontSize: '2rem', cursor: 'pointer' }}
-                            onClick={() => toggleStorage(index)}
+                            onClick={() => toggleStorage(row.loginId)}
                           />
                           <FaTrashAlt
                             style={{ color: 'red', fontSize: '2rem', cursor: 'pointer' }}
-                            onClick={() => handleDeleteRow(index)}
+                            onClick={() => handleDeleteRow(row.loginId)}
                           />
                         </div>
                       ) : (
                         <button
                           className={styles.submitButton}
-                          onClick={() => handleSave(index)}
+                          onClick={() => handleSave(row.loginId)}
                         >
                           저장하기
                         </button>
@@ -211,7 +236,7 @@ export default function Registration({ users }) {
                   </td>
                   <td>
                     <AddImage
-                      index={index}
+                      index={row.loginId}
                       onImageUpload={handleImageUpload}
                       isStorage={row.isStorage}
                       initialImage={row.image}

--- a/src/components/recruitPage/RecruitMain.jsx
+++ b/src/components/recruitPage/RecruitMain.jsx
@@ -11,6 +11,7 @@ export default function RecruitMain() {
     openDate: null,
     deadline: null,
     resultDate: null,
+    semester: '',
   });
 
   const navigate = useNavigate();
@@ -20,13 +21,14 @@ export default function RecruitMain() {
       try {
         const res = await getScedules();
         if (res) {
-          const { openDate, deadline, resultDate } = res;
+          const { openDate, deadline, resultDate, semester } = res;
 
-          // 상태 업데이트 (openDate, deadline, resultDate)
+          // 상태 업데이트 (openDate, deadline, resultDate, semester)
           setSchedule({
             openDate: openDate ? new Date(openDate) : null,
             deadline: deadline ? new Date(deadline) : null,
             resultDate: resultDate ? new Date(resultDate) : null,
+            semester: semester || '',
           });
 
           checkTime(
@@ -66,7 +68,7 @@ export default function RecruitMain() {
 
   function handleRecruitButtonClick() {
     if (!schedule.openDate || !schedule.deadline || !schedule.resultDate) {
-      // 활성화된 지원서가 없을경우
+      //활성화된 지원서가 없을 경우
       alert('모집 기간이 아닙니다.');
       return;
     }
@@ -84,7 +86,7 @@ export default function RecruitMain() {
     <div className={styles.allContainer}>
       <div className={styles.D_dayContainer}>
         <p className={styles.dayText}>LIKELION SKU</p>
-        <p className={styles.mainText}>13기 아기사자 모집</p>
+        <p className={styles.mainText}>{schedule.semester}기 아기사자 모집</p>
       </div>
       <img
         src={LionImage}

--- a/src/components/resultPage/CheckResult.jsx
+++ b/src/components/resultPage/CheckResult.jsx
@@ -30,9 +30,21 @@ export default function CheckResult() {
         const response = await getDate({
           headers: { Authorization: `Bearer ${token}` },
         });
-        setCreatedAt(response.createdAt.replace('T', ' '));
+
+        if (!response.createdAt) {
+          navigate('/error', {
+            state: {
+              msg: '제출된 지원서가 없습니다.',
+              msg2: '지원서 상태에 이상이 있다면 문의 바랍니다.',
+              btnMsg: '홈으로 돌아가기',
+              url: '/',
+            },
+          });
+        } else {
+          setCreatedAt(response.createdAt.replace('T', ' '));
+        }
       } catch {
-        location.href = '/error';
+        navigate('/error');
       }
     };
 

--- a/src/components/resultPage/interview/component/InterviewScheduler.jsx
+++ b/src/components/resultPage/interview/component/InterviewScheduler.jsx
@@ -14,7 +14,7 @@ function InterviewScheduler({ isSubmitEnabled }) {
       try {
         const token = localStorage.getItem('token');
         if (!token) {
-          navigate('/login');
+          alert('로그인이 필요합니다.');
           return;
         }
 

--- a/src/components/resultPage/interview/component/InterviewScheduler.jsx
+++ b/src/components/resultPage/interview/component/InterviewScheduler.jsx
@@ -14,7 +14,7 @@ function InterviewScheduler({ isSubmitEnabled }) {
       try {
         const token = localStorage.getItem('token');
         if (!token) {
-          alert('로그인이 필요합니다.');
+          navigate('/login');
           return;
         }
 


### PR DESCRIPTION
1. 지원서가 없는 사용자가 result접근시 error화면 ui변경
2. 헤더이름 멋사인 편집하기 => 구성원 편집하기
3. 파트에 "지원자" 추가
4. 역할별 분류 토글 추가
5. index로 관리하던 토글을 loginId로 관리하도록 변경
6. recruit페이지 기수 api 응답값 사용하도록 수정