### PR TITLE
🐛 Fix: 비밀번호 변경 시 비밀번호 확인 유효성 검사도 실시간으로 반영되게 수정

### DIFF
--- a/src/components/signup/SignupSection2.jsx
+++ b/src/components/signup/SignupSection2.jsx
@@ -1,7 +1,12 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styles from './SignupSection.module.css';
-import { handleInputChangeNumber, handleInputChangeSignup, handleInputChangePW_valid } from '@utils/inputOnChange.js';
+import {
+  handleInputChangeNumber,
+  handleInputChangeSignup,
+  handleInputChangePW,
+  handleInputChangePW_valid,
+} from '@utils/inputOnChange.js';
 import { handleSignup } from '@utils/register.js';
 import ConsentTable from './ConsentTable';
 
@@ -79,7 +84,7 @@ export default function SignupSection({ email, setSignupSuccess, setNow }) {
                 id='password'
                 value={form.password}
                 className={errors.password ? styles['invalid'] : form.password ? styles['valid'] : ''}
-                onChange={handleInputChangeSignup(setForm, setErrors)}
+                onChange={handleInputChangePW(setForm, setErrors, form)}
                 autoComplete='off'
                 required
               ></input>

--- a/src/utils/inputOnChange.js
+++ b/src/utils/inputOnChange.js
@@ -60,6 +60,38 @@ export function handleInputChangeNumber(setState, setErrors) {
   };
 }
 
+// 비밀번호 입력받기
+export function handleInputChangePW(setState, setErrors, form) {
+  return function (event) {
+    const { id, value } = event.target; // 입력 필드의 id과 value 추출
+
+    // 입력값 업데이트
+    setState((prev) => ({
+      ...prev,
+      [id]: value,
+    }));
+
+    setErrors((prevErrors) => {
+      // 기존 errors 상태를 유지하면서 현재 입력된 필드만 검사
+      const newErrors = validateInput_signup({ ...form, [id]: value });
+
+      // 현재 비밀번호 확인 값이 공백이면 비밀번호만, 아니면 비밀번호 확인도 같이 확인
+      if (form.password_valid === '') {
+        return {
+          ...prevErrors, // 기존 에러 메시지 유지
+          [id]: newErrors[id], // 비밀번호 에러 메시지만 업데이트
+        };
+      } else {
+        return {
+          ...prevErrors, // 기존 에러 메시지 유지
+          [id]: newErrors[id], // 현재 입력 필드의 에러 메시지만 업데이트
+          password_valid: newErrors.password_valid, // 비밀번호 확인도 같이 변경
+        };
+      }
+    });
+  };
+}
+
 // 비밀번호 확인 입력받기
 export function handleInputChangePW_valid(setState, setErrors, form) {
   return function (event) {


### PR DESCRIPTION
[현재] 비밀번호, 비밀번호 확인 완료된 후에 비밀번호 변경하면 비번 확인 에러 메세지가 갱신 되지 않음.
(비번 확인은 입력되지 않았으므로 유효성 검사를 안 해서)


[수정] SignupSection2.jsx, utils>inputOnChange.js
비밀번호 입력 시, 비밀번호 확인 란이 공백이 아니라면, 비밀번호 확인 유효성 검사도 같이 진행.
=> 비번이 수정되면 비번 확인도 같이 에러 메세지가 같이 변경됨. 
(둘이 다르면 비밀번호 확인 쪽에 '비밀번호와 일치하지 않습니다.' 문구 나오게 됨.)


