### PR TITLE
:recycle: Refactor: LEAD/COLEAD 조회 로직 사용자용 API 기준으로 수정

### DIFF
--- a/src/api/aboutAPI.js
+++ b/src/api/aboutAPI.js
@@ -10,9 +10,9 @@ export async function getAbout(semester, parts, role) {
   }
 }
 
-export async function getChairman(role) {
+export async function getChairman(semester, role) {
   try {
-    const baseUrl = `${import.meta.env.VITE_APP_GET_ABOUT}/admin/role/${role}`;
+    const baseUrl = `${import.meta.env.VITE_APP_GET_ABOUT}/semester/${semester}/role/${role}`;
     const res = await APIService.private.get(baseUrl);
     return res;
   } catch {

--- a/src/components/aboutPage/Chairman.jsx
+++ b/src/components/aboutPage/Chairman.jsx
@@ -11,36 +11,46 @@ export default function Chairman({ year }) {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (year) {
-      fetchChairmanData('LEAD', setChairman); // 회장 데이터 요청
-      fetchChairmanData('COLEAD', setCoChairman); // 부회장 데이터 요청
-    }
-  }, [year]);
+    if (!year) return;
 
-  async function fetchChairmanData(role, setter) {
-    setIsLoading(true);
-    try {
-      const response = await getChairman(role);
-      const users = response?.users || [];
+    const fetchBoth = async () => {
+      setIsLoading(true);
+      try {
+        const [leadRes, coLeadRes] = await Promise.all([getChairman(year, 'LEAD'), getChairman(year, 'COLEAD')]);
 
-      // year(semester)와 동일한 데이터 필터링
-      const filteredMember = users.find((user) => user.semester == year);
-      if (filteredMember) {
-        setter({
-          name: filteredMember.userName,
-          department: `${filteredMember.department} ${filteredMember.studentId.slice(2, 4)}학번`,
-          profileImage: filteredMember.profileImageUrl,
-          role: role === 'LEAD' ? '회장' : '부회장', // 역할 이름 변환
-        });
-      } else {
-        setter(null);
+        const lead = leadRes?.users?.[0];
+        const coLead = coLeadRes?.users?.[0];
+
+        setChairman(
+          lead
+            ? {
+                name: lead.userName,
+                department: `${lead.department} ${lead.studentId}`,
+                profileImage: lead.profileImageUrl,
+                role: '회장',
+              }
+            : null,
+        );
+
+        setCoChairman(
+          coLead
+            ? {
+                name: coLead.userName,
+                department: `${coLead.department} ${coLead.studentId}`,
+                profileImage: coLead.profileImageUrl,
+                role: '부회장',
+              }
+            : null,
+        );
+      } catch {
+        location.href = '/error';
+      } finally {
+        setIsLoading(false);
       }
-    } catch {
-      location.href = '/error';
-    } finally {
-      setIsLoading(false); // 로딩 종료
-    }
-  }
+    };
+
+    fetchBoth();
+  }, [year]);
 
   return (
     <div className={styles.allContainer}>


### PR DESCRIPTION
## ✨ 새로운 기능
- LEAD/COLEAD 조회 로직을 관리자용 API에서 사용자용 API로 변경
- 민감정보가 포함된 응답 사용을 제거

## 🛠 개발 상세
- `/admin/role/{role}` 호출을 제거하고 `/semester/{semester}/role/{role}` 사용자용 엔드포인트로 교체
- 응답 구조 변경에 따라 users[0] 기반으로 데이터 처리 로직 수정
- Promise.all을 활용해 대표/부대표 데이터를 병렬 요청하도록 개선

## 🔗 관련 문서 / 이슈
- issue: #215 