### PR TITLE
♻️ Refactor: 프로젝트 목록 필터/페이지 상태 관리 구조 개선

### DIFF
--- a/src/components/ProjectPage/CustomDropdown.jsx
+++ b/src/components/ProjectPage/CustomDropdown.jsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import styles from './CustomDropdown.module.css';
 import arrow_down from '@assets/projectPage/arrow_down.webp';
 
-function CustomDropdown({ options, defaultOption, onSelect, hideArrow = false }) {
+function CustomDropdown({ options, value, onSelect, hideArrow = false }) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [selectedOption, setSelectedOption] = useState(defaultOption);
+  const selectedOption = value;
 
   function toggleDropdown() {
     setIsDropdownOpen(function (prev) {
@@ -13,7 +13,6 @@ function CustomDropdown({ options, defaultOption, onSelect, hideArrow = false })
   }
 
   function handleSelect(option) {
-    setSelectedOption(option);
     setIsDropdownOpen(false);
     onSelect(option);
   }

--- a/src/components/ProjectPage/ProjectPageLayout.jsx
+++ b/src/components/ProjectPage/ProjectPageLayout.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useNavigate, useSearchParams, useLocation } from 'react-router-dom';
 import { TailSpin } from 'react-loader-spinner';
 import styles from './ProjectPageLayout.module.css';
 import CustomDropdown from './CustomDropdown.jsx';
@@ -9,14 +9,23 @@ import projectAPI from '@/api/projectAPI';
 
 function ProjectPageLayout({ isAdmin }) {
   const [projects, setProjects] = useState([]);
-  const [currentPage, setCurrentPage] = useState(0);
   const [totalElements, setTotalElements] = useState(0);
   const [pageSize, setPageSize] = useState(6);
-  const [menuVisible, setMenuVisible] = useState(null); // 메뉴 표시 상태 관리
-  const [selectedType, setSelectedType] = useState('ALL');
+  const [menuVisible, setMenuVisible] = useState(null);
   const [loading, setLoading] = useState(false);
-  const menuRefs = useRef({}); // 각 프로젝트 메뉴별 참조 객체
+
+  const menuRefs = useRef({});
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const selectedType = (searchParams.get('type') ?? 'ALL').toUpperCase();
+  const page1 = parseInt(searchParams.get('page') ?? '1', 10);
+  const currentPage1 = Number.isFinite(page1) && page1 > 0 ? page1 : 1;
+
+  // API용 0-based
+  const currentPage0 = currentPage1 - 1;
 
   // 타입 매핑 (영문 -> 한글)
   const typeMap = {
@@ -26,11 +35,37 @@ function ProjectPageLayout({ isAdmin }) {
     ALL: '전체 프로젝트',
   };
 
+  const typeLabelMap = {
+    ALL: '전체 프로젝트',
+    HACKATHON: '중앙해커톤',
+    IDEATHON: '아이디어톤',
+    SIDE: '자체프로젝트',
+  };
+
+  const updateQuery = useCallback(
+    (updates, options = { replace: true }) => {
+      const next = new URLSearchParams(searchParams);
+
+      Object.entries(updates).forEach(([key, value]) => {
+        if (value === undefined || value === null || value === '') {
+          next.delete(key);
+        } else {
+          next.set(key, String(value));
+        }
+      });
+
+      if (next.toString() !== searchParams.toString()) {
+        setSearchParams(next, options);
+      }
+    },
+    [searchParams, setSearchParams],
+  );
+
   useEffect(() => {
     async function fetchProjects() {
       setLoading(true);
       try {
-        const response = await projectAPI.fetchProjects(selectedType.toUpperCase(), currentPage);
+        const response = await projectAPI.fetchProjects(selectedType, currentPage0);
 
         const { content = [], totalElements: serverTotalElements = 0, pageSize: serverPageSize = 6 } = response || {};
 
@@ -42,14 +77,15 @@ function ProjectPageLayout({ isAdmin }) {
         setProjects([]);
         setTotalElements(0);
         setPageSize(6);
-        setCurrentPage(0);
+
+        updateQuery({ page: 1 });
       } finally {
         setLoading(false);
       }
     }
 
     fetchProjects();
-  }, [currentPage, selectedType]);
+  }, [selectedType, currentPage0, updateQuery]);
 
   useEffect(() => {
     function handleClickOutside(event) {
@@ -59,39 +95,18 @@ function ProjectPageLayout({ isAdmin }) {
       }
     }
     document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
+    return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [menuVisible]);
 
-  function handleDelete(projectId) {
-    const confirmDelete = window.confirm('프로젝트가 삭제됩니다.');
-    if (confirmDelete) {
-      (async () => {
-        try {
-          await projectAPI.deleteProject(projectId); // 삭제 API 호출
-
-          // 삭제 후 프로젝트 목록 다시 로드
-          setProjects((prevProjects) => prevProjects.filter((project) => project.id !== projectId));
-
-          // 삭제 성공 알림
-          alert('프로젝트가 성공적으로 삭제되었습니다.');
-        } catch {
-          alert('프로젝트 삭제에 실패했습니다.');
-        }
-      })();
-    }
-  }
-
   function handleTypeSelect(type) {
-    const typeMap = {
+    const map = {
       '전체 프로젝트': 'ALL',
       중앙해커톤: 'HACKATHON',
       아이디어톤: 'IDEATHON',
       자체프로젝트: 'SIDE',
     };
-    setSelectedType(typeMap[type] || 'ALL'); // 매핑된 값 설정
-    setCurrentPage(0);
+
+    updateQuery({ type: map[type] || 'ALL', page: 1 });
   }
 
   function handleAddProjectClick() {
@@ -99,7 +114,7 @@ function ProjectPageLayout({ isAdmin }) {
   }
 
   function handleProjectCardClick(projectId) {
-    navigate(`/project/${projectId}`);
+    navigate(`/project/${projectId}${location.search}`);
   }
 
   function handleEditProjectClick(project) {
@@ -108,6 +123,21 @@ function ProjectPageLayout({ isAdmin }) {
 
   function toggleMenu(projectId) {
     setMenuVisible((prev) => (prev === projectId ? null : projectId));
+  }
+
+  function handleDelete(projectId) {
+    const confirmDelete = window.confirm('프로젝트가 삭제됩니다.');
+    if (!confirmDelete) return;
+
+    (async () => {
+      try {
+        await projectAPI.deleteProject(projectId);
+        setProjects((prev) => prev.filter((p) => p.id !== projectId));
+        alert('프로젝트가 성공적으로 삭제되었습니다.');
+      } catch {
+        alert('프로젝트 삭제에 실패했습니다.');
+      }
+    })();
   }
 
   return (
@@ -126,7 +156,7 @@ function ProjectPageLayout({ isAdmin }) {
         <div className={styles.selectBoxContainer}>
           <CustomDropdown
             options={['전체 프로젝트', '중앙해커톤', '아이디어톤', '자체프로젝트']}
-            defaultOption='전체 프로젝트'
+            value={typeLabelMap[selectedType] ?? '전체 프로젝트'}
             onSelect={handleTypeSelect}
           />
         </div>
@@ -217,10 +247,10 @@ function ProjectPageLayout({ isAdmin }) {
         </div>
       )}
       <Pagination
-        currentPage0={currentPage}
+        currentPage0={currentPage0}
         totalElements={totalElements}
         pageSize={pageSize}
-        onPageChange0={setCurrentPage}
+        onPageChange0={(page0) => updateQuery({ page: page0 + 1 })}
       />
     </div>
   );


### PR DESCRIPTION
## ✨ 새로운 기능
- 프로젝트 상세 페이지에서 뒤로가기 시 목록의 필터/페이지 상태가 유지되도록 개선
- URL query(type, page) 기반으로 목록 상태를 관리하도록 변경

## 🛠 개발 상세
- useSearchParams를 활용하여 type, page를 URL query로 관리
- URL은 1-based 페이지로 표현하고 API 호출 시 0-based로 변환 처리
- CustomDropdown을 controlled 컴포넌트로 전환하여 부모 상태와 동기화
- 상세 페이지 이동 시 location.search를 유지하여 목록 상태 복원이 가능하도록 구현

## 🔗 관련 문서 / 이슈
- issue: #219 